### PR TITLE
Remove dependency on "R.utils" package

### DIFF
--- a/RWinOut.py
+++ b/RWinOut.py
@@ -26,7 +26,7 @@ class RWinOutWatcher(object):
 			# compute output just when there  are lines of code (header and code)
 			if codeIdx > 0 and len(Rcode) > 0:
 				self.printROut = True
-				return self.original_run_cell(header + '\n..RROUT.. <- captureOutput({\n' + Rcode + '\n})', **kw)
+				return self.original_run_cell(header + '\n..RROUT.. <- capture.output({\n' + Rcode + '\n})', **kw)
 			
 		# otherwise, use original method
 		return self.original_run_cell(raw_cell, **kw)
@@ -38,7 +38,6 @@ def load_ipython_extension(ip):
 	
 	# loading magic and libraries
 	ip.run_line_magic('load_ext', 'rpy2.ipython')
-	ip.run_line_magic('R', 'library(R.utils)')
 	ip.run_line_magic('config', 'Application.verbose_crash=True')
 	
 	# registering events


### PR DESCRIPTION
Loading the "R.utils" package in my environment (Windows 10, conda 4.7, Python 3.7, rpy 2.9) caused an undiagnosable errror: "ValueError: Buffer for this type not yet supported." However this dependency is not needed since base R has a `capture.output` function which achieves the same goal as `captureOutput` in R.utils. I think removing unnecessary dependencies is always an improvement, but you are welcome to accept/reject my pull request at your discretion.